### PR TITLE
Update local.conf

### DIFF
--- a/dovecot/local.conf
+++ b/dovecot/local.conf
@@ -1,7 +1,7 @@
 protocols = imap pop3
 disable_plaintext_auth = no
 
-mail_location = maildir:/home/vmail/%d
+mail_location = maildir:/home/vmail/%d/%u
 
 auth_default_realm = {{APP_HOST}}
 auth_verbose = yes
@@ -36,4 +36,21 @@ service auth {
         group = postfix
     }
     user = root
+}
+namespace inbox {
+  inbox = yes
+
+  # set these to autocreate or else thunderbird will complain
+  mailbox Trash {
+    auto = create
+    special_use = \Trash
+  }
+  mailbox Drafts {
+    auto = subscribe
+    special_use = \Drafts
+  }
+  mailbox Sent {
+    auto = subscribe # autocreate and autosubscribe the Sent mailbox
+    special_use = \Sent
+  }
 }


### PR DESCRIPTION
mail_location should have added /%u (user) to path. Otherwise all users mail would land in one como directory for every domain. Added also default mailbox folders for send, drafts and trash.
